### PR TITLE
Disable queueing for topic updates

### DIFF
--- a/src/main/java/network/parthenon/amcdb/discord/DiscordService.java
+++ b/src/main/java/network/parthenon/amcdb/discord/DiscordService.java
@@ -169,7 +169,12 @@ public class DiscordService {
      */
     private void setChannelTopic(TextChannel channel, String topic) {
         if(channel != null) {
-            channel.getManager().setTopic(topic).queue();
+            // disable JDA queueing on this request.
+            // if JDA gets a 429 rate limit error with queuing enabled, it automatically
+            // tries to resend the request after the rate limit expires, which is
+            // counterproductive because the data is old at that point and the extra
+            // request causes the next intentional topic update to get rate limited.
+            channel.getManager().setTopic(topic).submit(false);
         }
     }
 

--- a/src/main/resources/amcdb.properties
+++ b/src/main/resources/amcdb.properties
@@ -84,9 +84,10 @@ amcdb.discord.broadcastMessageFormat=%message%
 amcdb.discord.batching.timeLimit=1000
 
 # Interval at which AMCDB will attempt to update channel topics, in seconds.
-# Do not set this value lower than 5 minutes - Discord enforces rate limiting
-# and the extra updates won't apply anyway. If it is set extremely low, you
-# may get your bot banned for spamming the API.
+# Do not set this value lower than 5 minutes; Discord enforces rate limiting
+# at a rate of 2 topic updates per 10 minutes per channel, so the extra updates
+# won't apply anyway. If this setting is set extremely low, you may get your
+# bot banned for spamming the API.
 # This setting has no effect if both topicFormat properties are disabled.
 amcdb.discord.topicUpdateInterval=330
 


### PR DESCRIPTION
This prevents self-perpetuating 429 errors