### PR TITLE
Fix regression preventing console commands from being executed

### DIFF
--- a/src/main/java/network/parthenon/amcdb/AMCDB.java
+++ b/src/main/java/network/parthenon/amcdb/AMCDB.java
@@ -3,12 +3,11 @@ package network.parthenon.amcdb;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.server.MinecraftServer;
 import network.parthenon.amcdb.config.AMCDBConfig;
 import network.parthenon.amcdb.config.AMCDBPropertiesConfig;
-import network.parthenon.amcdb.discord.DiscordFormatter;
 import network.parthenon.amcdb.discord.DiscordService;
 import network.parthenon.amcdb.messaging.BackgroundMessageBroker;
+import network.parthenon.amcdb.messaging.MessageBroker;
 import network.parthenon.amcdb.minecraft.MinecraftService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +33,7 @@ public class AMCDB implements ModInitializer {
 
 	private DiscordService discordService;
 
-	private BackgroundMessageBroker broker;
+	private MessageBroker broker;
 
 	private AMCDBConfig config;
 

--- a/src/main/java/network/parthenon/amcdb/discord/DiscordListener.java
+++ b/src/main/java/network/parthenon/amcdb/discord/DiscordListener.java
@@ -4,14 +4,13 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import network.parthenon.amcdb.config.DiscordConfig;
+import network.parthenon.amcdb.messaging.MessageBroker;
 import network.parthenon.amcdb.messaging.component.InternalMessageComponent;
 import network.parthenon.amcdb.messaging.component.TextComponent;
 import network.parthenon.amcdb.messaging.message.BroadcastMessage;
 import network.parthenon.amcdb.messaging.message.ChatMessage;
 import network.parthenon.amcdb.messaging.message.ConsoleMessage;
 import network.parthenon.amcdb.messaging.message.InternalMessage;
-import network.parthenon.amcdb.messaging.BackgroundMessageBroker;
-import network.parthenon.amcdb.messaging.component.EntityReference;
 
 import java.util.List;
 
@@ -23,9 +22,9 @@ public class DiscordListener extends ListenerAdapter {
 
     private final DiscordFormatter formatter;
 
-    private final BackgroundMessageBroker broker;
+    private final MessageBroker broker;
 
-    public DiscordListener(DiscordService discordService, DiscordConfig config, BackgroundMessageBroker broker) {
+    public DiscordListener(DiscordService discordService, DiscordConfig config, MessageBroker broker) {
         this.discordService = discordService;
         this.config = config;
         this.formatter = new DiscordFormatter(discordService, config);
@@ -49,8 +48,8 @@ public class DiscordListener extends ListenerAdapter {
                 && e.getChannel().getIdLong() == config.getDiscordChatChannel().orElseThrow()) {
             handleChatMessage(e.getMessage());
         }
-        else if(config.getDiscordChatChannel().isPresent()
-                && e.getChannel().getIdLong() == config.getDiscordChatChannel().orElseThrow()) {
+        else if(config.getDiscordConsoleChannel().isPresent()
+                && e.getChannel().getIdLong() == config.getDiscordConsoleChannel().orElseThrow()) {
             handleConsoleMessage(e.getMessage());
         }
     }

--- a/src/main/java/network/parthenon/amcdb/discord/DiscordService.java
+++ b/src/main/java/network/parthenon/amcdb/discord/DiscordService.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import network.parthenon.amcdb.config.AMCDBPropertiesConfig;
 import network.parthenon.amcdb.config.DiscordConfig;
-import network.parthenon.amcdb.messaging.BackgroundMessageBroker;
+import network.parthenon.amcdb.messaging.MessageBroker;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -30,7 +30,7 @@ public class DiscordService {
 
     private final DiscordConfig config;
 
-    private final BackgroundMessageBroker broker;
+    private final MessageBroker broker;
 
     private JDA jdaInstance;
 
@@ -42,7 +42,7 @@ public class DiscordService {
 
     private BatchingSender consoleSender;
 
-    public DiscordService(BackgroundMessageBroker broker, DiscordConfig config) {
+    public DiscordService(MessageBroker broker, DiscordConfig config) {
 
         this.config = config;
 

--- a/src/main/java/network/parthenon/amcdb/messaging/BackgroundMessageBroker.java
+++ b/src/main/java/network/parthenon/amcdb/messaging/BackgroundMessageBroker.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ThreadFactory;
  * Message broker that dispatches messages to handlers using a background thread
  * to prevent blocking other threads.
  */
-public class BackgroundMessageBroker {
+public class BackgroundMessageBroker implements MessageBroker {
 
     private static final String THREAD_NAME = "AMCDB Dispatcher";
 
@@ -36,24 +36,12 @@ public class BackgroundMessageBroker {
         });
     }
 
-    /**
-     * Subscribes a handler to messages.
-     * @param handler The handler to subscribe.
-     */
+    @Override
     public void subscribe(MessageHandler handler) {
         this.handlers.add(handler);
     }
 
-    /**
-     * Publishes message(s) to the queue and returns immediately.
-     * Handlers are invoked on separate threads.
-     *
-     * This method is synchronized so that if multiple messages are
-     * supplied in a single call, they are guaranteed to be published
-     * sequentially with no gaps.
-     *
-     * @param messages The message(s) to publish.
-     */
+    @Override
     public synchronized void publish(InternalMessage... messages) {
         for(InternalMessage message : messages) {
             this.dispatchToHandlers(message);

--- a/src/main/java/network/parthenon/amcdb/messaging/MessageBroker.java
+++ b/src/main/java/network/parthenon/amcdb/messaging/MessageBroker.java
@@ -1,0 +1,24 @@
+package network.parthenon.amcdb.messaging;
+
+import network.parthenon.amcdb.messaging.message.InternalMessage;
+
+public interface MessageBroker {
+    /**
+     * Subscribes a handler to messages.
+     *
+     * @param handler The handler to subscribe.
+     */
+    void subscribe(MessageHandler handler);
+
+    /**
+     * Publishes message(s) to the queue and returns immediately.
+     * Handlers are invoked on separate threads.
+     * <p>
+     * This method is synchronized so that if multiple messages are
+     * supplied in a single call, they are guaranteed to be published
+     * sequentially with no gaps.
+     *
+     * @param messages The message(s) to publish.
+     */
+    void publish(InternalMessage... messages);
+}

--- a/src/main/java/network/parthenon/amcdb/minecraft/InGameMessageHandler.java
+++ b/src/main/java/network/parthenon/amcdb/minecraft/InGameMessageHandler.java
@@ -10,7 +10,7 @@ import network.parthenon.amcdb.config.MinecraftConfig;
 import network.parthenon.amcdb.messaging.message.ChatMessage;
 import network.parthenon.amcdb.messaging.message.BroadcastMessage;
 import network.parthenon.amcdb.messaging.message.InternalMessage;
-import network.parthenon.amcdb.messaging.BackgroundMessageBroker;
+import network.parthenon.amcdb.messaging.MessageBroker;
 import network.parthenon.amcdb.messaging.component.EntityReference;
 
 public class InGameMessageHandler {
@@ -21,9 +21,9 @@ public class InGameMessageHandler {
 
     private final MinecraftFormatter formatter;
 
-    private final BackgroundMessageBroker broker;
+    private final MessageBroker broker;
 
-    public InGameMessageHandler(MinecraftService minecraftService, MinecraftConfig config, BackgroundMessageBroker broker) {
+    public InGameMessageHandler(MinecraftService minecraftService, MinecraftConfig config, MessageBroker broker) {
         this.minecraftService = minecraftService;
         this.config = config;
         this.formatter = new MinecraftFormatter(minecraftService, config);

--- a/src/main/java/network/parthenon/amcdb/minecraft/LogTailer.java
+++ b/src/main/java/network/parthenon/amcdb/minecraft/LogTailer.java
@@ -2,7 +2,7 @@ package network.parthenon.amcdb.minecraft;
 
 import network.parthenon.amcdb.AMCDB;
 import network.parthenon.amcdb.messaging.message.ConsoleMessage;
-import network.parthenon.amcdb.messaging.BackgroundMessageBroker;
+import network.parthenon.amcdb.messaging.MessageBroker;
 import org.apache.commons.io.input.Tailer;
 import org.apache.commons.io.input.TailerListener;
 
@@ -14,9 +14,9 @@ public class LogTailer implements TailerListener {
 
     private Tailer tailer;
 
-    private final BackgroundMessageBroker broker;
+    private final MessageBroker broker;
 
-    private LogTailer(BackgroundMessageBroker broker) {
+    private LogTailer(MessageBroker broker) {
         this.broker = broker;
     }
 
@@ -50,7 +50,7 @@ public class LogTailer implements TailerListener {
      *
      * @param file The file to watch.
      */
-    public static void watchFile(File file, BackgroundMessageBroker broker) {
+    public static void watchFile(File file, MessageBroker broker) {
         TailerListener listener = new LogTailer(broker);
         Tailer tailer = new Tailer(file, listener);
         Thread tailerThread = new Thread(tailer);

--- a/src/main/java/network/parthenon/amcdb/minecraft/MinecraftPublisher.java
+++ b/src/main/java/network/parthenon/amcdb/minecraft/MinecraftPublisher.java
@@ -46,7 +46,8 @@ public class MinecraftPublisher implements MessageHandler {
             String command = message.getUnformattedContents();
             AMCDB.LOGGER.info("Executing console command from %s user %s (id=%s): %s".formatted(
                     message.getSourceId(),
-                    ((ConsoleMessage) message).getAuthor().getDisplayName(),
+                    // Log user's tag rather than their display name, as the tag is more permanent
+                    ((ConsoleMessage) message).getAuthor().getAlternateName(),
                     ((ConsoleMessage) message).getAuthor().getEntityId(),
                     command
             ));

--- a/src/main/java/network/parthenon/amcdb/minecraft/MinecraftService.java
+++ b/src/main/java/network/parthenon/amcdb/minecraft/MinecraftService.java
@@ -5,7 +5,7 @@ import net.fabricmc.fabric.api.message.v1.ServerMessageEvents;
 import net.minecraft.server.MinecraftServer;
 import network.parthenon.amcdb.config.AMCDBPropertiesConfig;
 import network.parthenon.amcdb.config.MinecraftConfig;
-import network.parthenon.amcdb.messaging.BackgroundMessageBroker;
+import network.parthenon.amcdb.messaging.MessageBroker;
 
 import java.io.File;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,7 +18,7 @@ public class MinecraftService {
 
     private final MinecraftConfig config;
 
-    private final BackgroundMessageBroker broker;
+    private final MessageBroker broker;
 
     private final ConcurrentMap<String, Integer> recentlyPublishedContents;
 
@@ -29,7 +29,7 @@ public class MinecraftService {
      * @param broker
      * @param config
      */
-    public MinecraftService(BackgroundMessageBroker broker, MinecraftConfig config) {
+    public MinecraftService(MessageBroker broker, MinecraftConfig config) {
         this.config = config;
         this.broker = broker;
         recentlyPublishedContents = new ConcurrentHashMap<>();

--- a/src/main/java/network/parthenon/amcdb/minecraft/StatusWatcher.java
+++ b/src/main/java/network/parthenon/amcdb/minecraft/StatusWatcher.java
@@ -1,7 +1,7 @@
 package network.parthenon.amcdb.minecraft;
 
 import network.parthenon.amcdb.AMCDB;
-import network.parthenon.amcdb.messaging.BackgroundMessageBroker;
+import network.parthenon.amcdb.messaging.MessageBroker;
 import network.parthenon.amcdb.messaging.component.TextComponent;
 import network.parthenon.amcdb.messaging.message.ServerStatusMessage;
 import network.parthenon.amcdb.util.IntervalRunnable;
@@ -12,9 +12,9 @@ public class StatusWatcher extends IntervalRunnable {
 
     private final MinecraftService minecraftService;
 
-    private final BackgroundMessageBroker broker;
+    private final MessageBroker broker;
 
-    public StatusWatcher(MinecraftService minecraftService, BackgroundMessageBroker broker) {
+    public StatusWatcher(MinecraftService minecraftService, MessageBroker broker) {
         super("AMCDB Server Status Watcher");
         this.minecraftService = minecraftService;
         this.broker = broker;

--- a/src/test/java/network/parthenon/amcdb/discord/DiscordListenerTest.java
+++ b/src/test/java/network/parthenon/amcdb/discord/DiscordListenerTest.java
@@ -1,0 +1,123 @@
+package network.parthenon.amcdb.discord;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import network.parthenon.amcdb.config.DiscordConfig;
+import network.parthenon.amcdb.discord.JDAMocks.MockChannel;
+import network.parthenon.amcdb.discord.JDAMocks.MockSelfUser;
+import network.parthenon.amcdb.discord.JDAMocks.MockUser;
+import network.parthenon.amcdb.messaging.MessageBroker;
+import network.parthenon.amcdb.messaging.message.ChatMessage;
+import network.parthenon.amcdb.messaging.message.ConsoleMessage;
+import network.parthenon.amcdb.messaging.message.InternalMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.OptionalLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DiscordListenerTest {
+
+    MessageBroker mockBroker;
+
+    DiscordService mockDiscordService;
+
+    JDA mockJDA;
+
+    @BeforeEach
+    public void setUp() {
+        mockBroker = Mockito.mock(MessageBroker.class);
+        mockDiscordService = Mockito.mock(DiscordService.class);
+        mockJDA = mockJDA();
+    }
+
+    /**
+     * Tests that a received chat message is published to the message broker.
+     */
+    @Test
+    public void chatMessage() {
+        DiscordConfig config = Mockito.mock(DiscordConfig.class);
+        Mockito.when(config.getDiscordChatChannel()).thenReturn(OptionalLong.of(1234));
+        Mockito.when(config.getDiscordConsoleChannel()).thenReturn(OptionalLong.of(2345));
+
+        DiscordListener listener = new DiscordListener(mockDiscordService, config, mockBroker);
+
+        listener.onMessageReceived(mockMessageReceivedEvent("test message", 1234, 555));
+
+        ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+        Mockito.verify(mockBroker).publish(messageCaptor.capture());
+        assertEquals("test message", messageCaptor.getValue().getUnformattedContents());
+        assertEquals("555", messageCaptor.getValue().getAuthor().getEntityId());
+    }
+
+    /**
+     * Tests that a received console message is published to the message broker
+     * when console execution is enabled.
+     */
+    @Test
+    public void consoleMessageExecutionEnabled() {
+        DiscordConfig config = Mockito.mock(DiscordConfig.class);
+        Mockito.when(config.getDiscordChatChannel()).thenReturn(OptionalLong.of(1234));
+        Mockito.when(config.getDiscordConsoleChannel()).thenReturn(OptionalLong.of(2345));
+        Mockito.when(config.getDiscordConsoleExecutionEnabled()).thenReturn(true);
+
+        DiscordListener listener = new DiscordListener(mockDiscordService, config, mockBroker);
+
+        listener.onMessageReceived(mockMessageReceivedEvent("test command", 2345, 555));
+
+        ArgumentCaptor<ConsoleMessage> messageCaptor = ArgumentCaptor.forClass(ConsoleMessage.class);
+        Mockito.verify(mockBroker).publish(messageCaptor.capture());
+        assertEquals("test command", messageCaptor.getValue().getUnformattedContents());
+        assertEquals("555", messageCaptor.getValue().getAuthor().getEntityId());
+    }
+
+    /**
+     * Tests that a received console message is *not* published to the message broker
+     * when console execution is disabled, and that a warning is sent to the console channel.
+     */
+    @Test
+    public void consoleMessageExecutionDisabled() {
+        DiscordConfig config = Mockito.mock(DiscordConfig.class);
+        Mockito.when(config.getDiscordChatChannel()).thenReturn(OptionalLong.of(1234));
+        Mockito.when(config.getDiscordConsoleChannel()).thenReturn(OptionalLong.of(2345));
+        Mockito.when(config.getDiscordConsoleExecutionEnabled()).thenReturn(false);
+
+        DiscordListener listener = new DiscordListener(mockDiscordService, config, mockBroker);
+
+        listener.onMessageReceived(mockMessageReceivedEvent("test command", 2345, 555));
+
+        Mockito.verify(mockBroker, Mockito.never()).publish(Mockito.any());
+        Mockito.verify(mockDiscordService).sendToConsoleChannel(Mockito.anyString());
+    }
+
+    /**
+     * Creates a mock JDA instance.
+     * @return
+     */
+    private JDA mockJDA() {
+        JDA mockJDA = Mockito.mock(JDA.class);
+        Mockito.when(mockJDA.getSelfUser()).thenReturn(new MockSelfUser());
+        return mockJDA;
+    }
+
+    /**
+     * Creates a MessageReceivedEvent containing a message with the
+     * specified content and author.
+     * @param message  The message contents.
+     * @param authorId The author ID to set.
+     * @return
+     */
+    private MessageReceivedEvent mockMessageReceivedEvent(String message, long channelId, long authorId) {
+        Message mockMessage = Mockito.mock(Message.class);
+        Mockito.when(mockMessage.getChannel()).thenReturn(new MockChannel(channelId));
+        Mockito.when(mockMessage.getAuthor()).thenReturn(new MockUser(authorId));
+        Mockito.when(mockMessage.getContentRaw()).thenReturn(message);
+
+        return new MessageReceivedEvent(mockJDA, 1L, mockMessage);
+    }
+}

--- a/src/test/java/network/parthenon/amcdb/discord/JDAMocks/MockChannel.java
+++ b/src/test/java/network/parthenon/amcdb/discord/JDAMocks/MockChannel.java
@@ -1,11 +1,14 @@
 package network.parthenon.amcdb.discord.JDAMocks;
 
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.attribute.IThreadContainer;
+import net.dv8tion.jda.api.entities.channel.concrete.*;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.requests.RestAction;
 
-public class MockChannel implements Channel {
+public class MockChannel implements MessageChannelUnion {
 
     private final long channelId;
 
@@ -40,5 +43,50 @@ public class MockChannel implements Channel {
     @Override
     public long getIdLong() {
         return channelId;
+    }
+
+    @Override
+    public PrivateChannel asPrivateChannel() {
+        return null;
+    }
+
+    @Override
+    public TextChannel asTextChannel() {
+        return null;
+    }
+
+    @Override
+    public NewsChannel asNewsChannel() {
+        return null;
+    }
+
+    @Override
+    public ThreadChannel asThreadChannel() {
+        return null;
+    }
+
+    @Override
+    public VoiceChannel asVoiceChannel() {
+        return null;
+    }
+
+    @Override
+    public IThreadContainer asThreadContainer() {
+        return null;
+    }
+
+    @Override
+    public GuildMessageChannel asGuildMessageChannel() {
+        return null;
+    }
+
+    @Override
+    public long getLatestMessageIdLong() {
+        return 0;
+    }
+
+    @Override
+    public boolean canTalk() {
+        return false;
     }
 }

--- a/src/test/java/network/parthenon/amcdb/discord/JDAMocks/MockSelfUser.java
+++ b/src/test/java/network/parthenon/amcdb/discord/JDAMocks/MockSelfUser.java
@@ -1,0 +1,36 @@
+package network.parthenon.amcdb.discord.JDAMocks;
+
+import net.dv8tion.jda.api.entities.SelfUser;
+import net.dv8tion.jda.api.managers.AccountManager;
+
+public class MockSelfUser extends MockUser implements SelfUser {
+
+    public MockSelfUser() {
+        super(99999999);
+    }
+
+    @Override
+    public long getApplicationIdLong() {
+        return 1L;
+    }
+
+    @Override
+    public boolean isVerified() {
+        return false;
+    }
+
+    @Override
+    public boolean isMfaEnabled() {
+        return false;
+    }
+
+    @Override
+    public long getAllowedFileSize() {
+        return 0;
+    }
+
+    @Override
+    public AccountManager getManager() {
+        return null;
+    }
+}


### PR DESCRIPTION
Discord messages sent to the console channel are now once again executed as commands when this feature is enabled. Tests have been added to verify this behavior.

Additionally, the user's tag is now logged instead of their nickname.