### PR TITLE
Improve validation of Discord webhook URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ to `amcdb.discord.chat.channel=`. It'll look like this:
 amcdb.discord.chat.channel=1046313040837832782
 ```
 If you want to set up a channel for the server console, copy its ID too and
-paste it next to `amcdb.discord.console.channel=`.
+paste it next to `amcdb.discord.console.channel=`. The console channel supports
+running commands that you send via Discord; this feature is disabled by default
+for safety, but you can enable it by changing the setting
+`amcdb.discord.channels.console.enableExecution=` to `true`.
 
 Then save the `amcdb.properties` file and start your Minecraft server again.
 If you've done everything correctly, anything you type in the game chat

--- a/src/main/java/network/parthenon/amcdb/discord/DiscordService.java
+++ b/src/main/java/network/parthenon/amcdb/discord/DiscordService.java
@@ -32,7 +32,7 @@ public class DiscordService {
      */
     public static final String DISCORD_SOURCE_ID = "Discord";
 
-    private static final Pattern WEBHOOK_URL_PATTERN = Pattern.compile("^https://discord.com/api/webhooks/(?<id>\\d+)/(?<token>[a-zA-Z0-9_]+)$");
+    private static final Pattern WEBHOOK_URL_PATTERN = Pattern.compile("^https://discord.com/api/webhooks/(?<id>\\d+)/(?<token>.+)$");
 
     private final DiscordConfig config;
 

--- a/src/main/resources/amcdb.properties
+++ b/src/main/resources/amcdb.properties
@@ -17,6 +17,9 @@ amcdb.discord.channels.chat=
 # If provided, this allows AMCDB to post in game chat messages to Discord
 # using the usernames and avatars of the Minecraft players.
 # Comment this line to disable webhook mode.
+# Note: Providing a webhook URL but disabling the chat channel configuration
+# above will effectively create a one-way connection where in-game messages
+# are posted to Discord, but Discord messages are not sent to in-game chat.
 #amcdb.discord.channels.chat.webhookUrl=
 
 # Channel topic format for the chat channel, updated regularly with server information
@@ -29,7 +32,7 @@ amcdb.discord.channels.chat=
 #   - %playersOnline% The number of players currently connected to the server
 #   - %maxPlayers%    The maximum number of players the server is configured to allow
 #   - %motd%          The server Message of the Day (MOTD)
-#   - %relativeTime%  The most recent (displayed as e.g. "10 seconds ago")
+#   - %relativeTime%  The most recent update time (displayed as e.g. "10 seconds ago")
 #   - %absoluteTime%  The most recent update time (displayed as e.g. "December 31, 2022 9:09 PM"
 #                     depending on client localization)
 # Comment this setting to disable updating the chat channel topic.
@@ -58,7 +61,7 @@ amcdb.discord.channels.console.topicFormat=MSPT: %mspt% - JVM Used Memory: %used
 # Allow executing server commands via posting to the console channel in Discord.
 # Before enabling this feature, make sure to restrict who can post in the
 # console channel!
-amcdb.discord.channels.console.enableExecution=true
+amcdb.discord.channels.console.enableExecution=false
 
 # Use server nicknames when forwarding messages containing mentions
 # (e.g. @user) from Discord to Minecraft.


### PR DESCRIPTION
Fixes #20

This changes the webhook URL pattern to allow any string in the token segment. AMCDB is really only interested in validating the webhook ID segment, and this change will prevent the webhook feature from breaking if Discord updates their token format in the future.