### PR TITLE
Fix parsing of underscores in Discord markdown

### DIFF
--- a/src/main/java/network/parthenon/amcdb/discord/MarkdownParser.java
+++ b/src/main/java/network/parthenon/amcdb/discord/MarkdownParser.java
@@ -196,6 +196,7 @@ class MarkdownParser {
                         new MarkdownToken(twoCharType, twoCharSubstring);
             }
 
+            // discord quirk special case #1
             if(token.type == MarkdownToken.Type.SINGLE_ASTERISK
                     && !currentUnmatchedTokenTypes.contains(MarkdownToken.Type.SINGLE_ASTERISK)
                     && i < markdown.length() - 1
@@ -205,6 +206,20 @@ class MarkdownParser {
                 // asterisk is followed by a space.
                 // this is not the case for the single underscore, only the asterisk.
                 continue;
+            }
+
+            // discord quirk special case #2
+            if(token.type == MarkdownToken.Type.SINGLE_UNDERSCORE
+                    && i < markdown.length() - 1
+                    && Character.isLetterOrDigit(markdown.charAt(i+1))
+            ) {
+                // when an underscore is followed by an alphanumeric character,
+                // it cannot be the *second* token of a matched pair
+                // (i.e. it cannot indicate the end of an italic span).
+                // however, it still can be the first token of a matched pair.
+                // therefore, we need to disqualify any preceding single underscores
+                // from being matched.
+                currentUnmatchedTokenTypes.remove(token.type);
             }
 
             if(currentTextTokenStart < i) {

--- a/src/test/java/network/parthenon/amcdb/discord/MarkdownParserTest.java
+++ b/src/test/java/network/parthenon/amcdb/discord/MarkdownParserTest.java
@@ -159,6 +159,16 @@ class MarkdownParserTest {
     }
 
     /**
+     * This test confirms we match a particular behavior of the real Discord client,
+     * which is that an underscore followed by an alphanumeric character cannot be
+     * the *closing* underscore of an italic span.
+     */
+    @Test
+    void underscoreInWordTest() {
+        markdownTest("Username_With_3_Underscores", List.of(new TextComponent("Username_With_3_Underscores")));
+    }
+
+    /**
      * Tests that a URL is properly detected and represented as a UrlComponent.
      */
     @Test


### PR DESCRIPTION
Fixes a bug where e.g. `Username_With_Underscores` would be interpreted as indicating italics, when the Discord client shows underscores instead.