### PR TITLE
Add configurable start/stop messages in chat channel

### DIFF
--- a/src/main/java/network/parthenon/amcdb/config/AMCDBPropertiesConfig.java
+++ b/src/main/java/network/parthenon/amcdb/config/AMCDBPropertiesConfig.java
@@ -47,6 +47,10 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
 
     private final String discordBroadcastMessageFormat;
 
+    private final Optional<String> getDiscordLifecycleStartedFormat;
+
+    private final Optional<String> getDiscordLifecycleStoppedFormat;
+
     private final long discordBatchingTimeLimit;
 
     private final long discordTopicUpdateInterval;
@@ -82,6 +86,8 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
         discordBroadcastMessageFormat = getRequiredProperty("amcdb.discord.broadcastMessageFormat");
         discordChatMessageFormat = getRequiredProperty("amcdb.discord.chatMessageFormat");
         discordWebhookChatMessageFormat = getRequiredProperty("amcdb.discord.webhookChatMessageFormat");
+        getDiscordLifecycleStartedFormat = getOptionalProperty("amcdb.discord.lifecycle.startedFormat");
+        getDiscordLifecycleStoppedFormat = getOptionalProperty("amcdb.discord.lifecycle.stoppedFormat");
         discordTopicUpdateInterval = getRequiredLong("amcdb.discord.topicUpdateInterval");
         discordBatchingTimeLimit = getRequiredLong("amcdb.discord.batching.timeLimit");
         minecraftLogFile = getRequiredProperty("amcdb.minecraft.logFile");
@@ -252,6 +258,12 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
     public String getDiscordBroadcastMessageFormat() {
         return discordBroadcastMessageFormat;
     }
+
+    @Override
+    public Optional<String> getDiscordLifecycleStartedFormat() { return getDiscordLifecycleStartedFormat; }
+
+    @Override
+    public Optional<String> getDiscordLifecycleStoppedFormat() { return getDiscordLifecycleStoppedFormat; }
 
     @Override
     public long getDiscordBatchingTimeLimit() {

--- a/src/main/java/network/parthenon/amcdb/config/DiscordConfig.java
+++ b/src/main/java/network/parthenon/amcdb/config/DiscordConfig.java
@@ -27,6 +27,10 @@ public interface DiscordConfig {
 
     String getDiscordBroadcastMessageFormat();
 
+    Optional<String> getDiscordLifecycleStartedFormat();
+
+    Optional<String> getDiscordLifecycleStoppedFormat();
+
     long getDiscordBatchingTimeLimit();
 
     long getDiscordTopicUpdateInterval();

--- a/src/main/java/network/parthenon/amcdb/discord/DiscordPublisher.java
+++ b/src/main/java/network/parthenon/amcdb/discord/DiscordPublisher.java
@@ -57,6 +57,32 @@ public class DiscordPublisher implements MessageHandler {
         else if(message instanceof ServerStatusMessage) {
             publishChannelTopics((ServerStatusMessage) message);
         }
+        else if(message instanceof ServerLifecycleMessage && discordService.isChatChannelEnabled()) {
+            publishLifecycleMessage((ServerLifecycleMessage) message);
+        }
+    }
+
+    /**
+     * Publishes a server lifecycle message according to the applicable configuration.
+     */
+    private void publishLifecycleMessage(ServerLifecycleMessage message) {
+        String format = null;
+
+        if(message.getEvent() == ServerLifecycleMessage.Event.STARTED && config.getDiscordLifecycleStartedFormat().isPresent()) {
+            format = config.getDiscordLifecycleStartedFormat().orElseThrow();
+        }
+        else if(message.getEvent() == ServerLifecycleMessage.Event.STOPPED && config.getDiscordLifecycleStoppedFormat().isPresent()) {
+            format = config.getDiscordLifecycleStoppedFormat().orElseThrow();
+        }
+
+        if(format != null) {
+            sendChatMessage(
+                    formatter.toDiscordRawContent(
+                            message.formatToComponents(format).stream(),
+                            DiscordService.DISCORD_MESSAGE_CHAR_LIMIT),
+                    null,
+                    null);
+        }
     }
 
     @Override

--- a/src/main/java/network/parthenon/amcdb/messaging/message/ServerLifecycleMessage.java
+++ b/src/main/java/network/parthenon/amcdb/messaging/message/ServerLifecycleMessage.java
@@ -1,0 +1,43 @@
+package network.parthenon.amcdb.messaging.message;
+
+/**
+ * Message notifying of a server lifecyle event (started, stopped, etc).
+ */
+public class ServerLifecycleMessage extends InternalMessage {
+
+    private Event event;
+
+    private ServerLifecycleMessage(String sourceId, String text, Event event) {
+        super(sourceId, text);
+        this.event = event;
+    }
+
+    /**
+     * Gets the event for this lifecycle message.
+     */
+    public Event getEvent() {
+        return event;
+    }
+
+    /**
+     * Creates a lifecycle message indicating that the server has started.
+     */
+    public static ServerLifecycleMessage started(String sourceId) {
+        return new ServerLifecycleMessage(sourceId, "Server started", Event.STARTED);
+    }
+
+    /**
+     * Creates a lifecycle message indicating that the server has stopped.
+     */
+    public static ServerLifecycleMessage stopped(String sourceId) {
+        return new ServerLifecycleMessage(sourceId, "Server stopped", Event.STOPPED);
+    }
+
+    /**
+     * Lifecycle event types.
+     */
+    public static enum Event {
+        STARTED,
+        STOPPED
+    }
+}

--- a/src/main/java/network/parthenon/amcdb/messaging/message/ServerStatusMessage.java
+++ b/src/main/java/network/parthenon/amcdb/messaging/message/ServerStatusMessage.java
@@ -63,7 +63,7 @@ public class ServerStatusMessage extends InternalMessage {
 
     /**
      * Creates a new ServerStatusMessage as of the current time.
-     * @param sourceId         The source ID of the system that generate this message (Minecraft).
+     * @param sourceId         The source ID of the system that generated this message (Minecraft).
      * @param mspt             Current milliseconds per tick (MSPT).
      * @param totalMemoryBytes Current total memory in bytes.
      * @param freeMemoryBytes  Current free memory in bytes.
@@ -77,7 +77,7 @@ public class ServerStatusMessage extends InternalMessage {
 
     /**
      * Creates a new ServerStatusMessage as of the specified time.
-     * @param sourceId         The source ID of the system that generate this message (Minecraft).
+     * @param sourceId         The source ID of the system that generated this message (Minecraft).
      * @param mspt             Current milliseconds per tick (MSPT).
      * @param totalMemoryBytes Current total memory in bytes.
      * @param freeMemoryBytes  Current free memory in bytes.

--- a/src/main/java/network/parthenon/amcdb/minecraft/MinecraftService.java
+++ b/src/main/java/network/parthenon/amcdb/minecraft/MinecraftService.java
@@ -6,6 +6,7 @@ import net.minecraft.server.MinecraftServer;
 import network.parthenon.amcdb.config.AMCDBPropertiesConfig;
 import network.parthenon.amcdb.config.MinecraftConfig;
 import network.parthenon.amcdb.messaging.MessageBroker;
+import network.parthenon.amcdb.messaging.message.ServerLifecycleMessage;
 
 import java.io.File;
 import java.util.concurrent.ConcurrentHashMap;
@@ -53,7 +54,12 @@ public class MinecraftService {
         // Defer starting status watcher until server is done loading
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             minecraftServerInstance = server;
+            broker.publish(ServerLifecycleMessage.started(MINECRAFT_SOURCE_ID));
             new StatusWatcher(this, broker).start(10000);
+        });
+
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
+            broker.publish(ServerLifecycleMessage.stopped(MINECRAFT_SOURCE_ID));
         });
     }
 

--- a/src/main/resources/amcdb.properties
+++ b/src/main/resources/amcdb.properties
@@ -90,6 +90,14 @@ amcdb.discord.webhookChatMessageFormat=%message%
 # If you want to display the actual % sign, use "\\%".
 amcdb.discord.broadcastMessageFormat=%message%
 
+# Format for server lifecycle (e.g. started/stopped) messages shown in the Discord chat channel.
+# Comment these to disable the messages from appearing in Discord.
+# You can customize the display of messages with these placeholders:
+#   - %origin%   : The system the message came from (e.g. Minecraft).
+#   - %message%  : The default message content ("Server started", "Server stopped", etc).
+#amcdb.discord.lifecycle.startedFormat=%message%!
+#amcdb.discord.lifecycle.stoppedFormat=%message%!
+
 # =============================================================
 # Advanced Discord configuration
 # =============================================================


### PR DESCRIPTION
These are disabled by default.

Fixes #30 