### PR TITLE
Add support for message filtering by type, content, and author

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,17 @@ To set up a webhook, follow these steps:
    and avatars!
 
 ## Upgrade
-Generally, you can upgrade AMCDB simply by replacing the `.jar` file with the new
-version.
+Generally, you can upgrade AMCDB simply by replacing the `.jar` file with the
+new version.
 
-Sometimes, a new version of AMCDB will require additional properties to be added
-to `amcdb.properties`. In this case, after updating the `.jar` file, your server
-will fail to start, with an error that a required property is missing.
+When you upgrade, it's a good idea to check whether new properties have been
+added to `amcdb.properties`; you can find latest version of the default
+configuration [here](/src/main/resources/amcdb.properties). Occasionally, new
+required properties are added; this will cause your server to fail to start
+after updating the `.jar` until you add the new properties to your
+configuration.
 
-To update your properties file on an existing installation:
+You can also update your properties file by forcing AMCDB to generate a new one:
 1. Stop your Minecraft server
 2. Rename `amcdb.properties` to a temporary name, e.g. `amcdb.properties.old`
 3. Update the `.jar` file and start your server. AMCDB will generate a new

--- a/src/main/java/network/parthenon/amcdb/config/AMCDBPropertiesConfig.java
+++ b/src/main/java/network/parthenon/amcdb/config/AMCDBPropertiesConfig.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, MinecraftConfig {
 
@@ -45,6 +46,14 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
 
     private final String discordBroadcastMessageFormat;
 
+    private final Optional<Pattern> discordMessageFilterPattern;
+
+    private final boolean discordMessageFilterExclude;
+
+    private final Optional<List<String>> discordIgnoredExternalUsers;
+
+    private final boolean discordIgnoreBroadcast;
+
     private final Optional<String> discordLifecycleStartedFormat;
 
     private final Optional<String> discordLifecycleStoppedFormat;
@@ -64,6 +73,12 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
     private final boolean minecraftTextColorsEnabled;
 
     private final String minecraftMessageFormat;
+
+    private final Optional<Pattern> minecraftMessageFilterPattern;
+
+    private final boolean minecraftMessageFilterExclude;
+
+    private final Optional<List<String>> minecraftIgnoredExternalUsers;
 
     private final String minecraftAvatarApiUrl;
 
@@ -92,6 +107,10 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
         discordBroadcastMessageFormat = getRequiredProperty("amcdb.discord.broadcastMessageFormat");
         discordChatMessageFormat = getRequiredProperty("amcdb.discord.chatMessageFormat");
         discordWebhookChatMessageFormat = getRequiredProperty("amcdb.discord.webhookChatMessageFormat");
+        discordMessageFilterPattern = getOptionalRegex("amcdb.discord.messageFilter.pattern");
+        discordMessageFilterExclude = getOptionalBoolean("amcdb.discord.messageFilter.exclude", true);
+        discordIgnoredExternalUsers = getOptionalList("amcdb.discord.ignoredExternalUsers");
+        discordIgnoreBroadcast = getOptionalBoolean("amcdb.discord.ignoreBroadcast", false);
         discordLifecycleStartedFormat = getOptionalProperty("amcdb.discord.lifecycle.startedFormat");
         discordLifecycleStoppedFormat = getOptionalProperty("amcdb.discord.lifecycle.stoppedFormat");
         discordAlertMsptThreshold = getOptionalLong("amcdb.discord.alert.msptThreshold");
@@ -102,6 +121,9 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
         discordBatchingTimeLimit = getRequiredLong("amcdb.discord.batching.timeLimit");
         minecraftLogFile = getRequiredProperty("amcdb.minecraft.logFile");
         minecraftMessageFormat = getRequiredProperty("amcdb.minecraft.messageFormat");
+        minecraftMessageFilterPattern = getOptionalRegex("amcdb.minecraft.messageFilter.pattern");
+        minecraftMessageFilterExclude = getOptionalBoolean("amcdb.minecraft.messageFilter.exclude", true);
+        minecraftIgnoredExternalUsers = getOptionalList("amcdb.minecraft.ignoredExternalUsers");
         minecraftTextColorsEnabled = getOptionalBoolean("amcdb.minecraft.showTextColors", true);
         minecraftAvatarApiUrl = getRequiredProperty("amcdb.minecraft.avatarApi.url");
     }
@@ -145,6 +167,10 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
         return getRequiredProperty(key, v -> Arrays.stream(v.split(",")).map(num -> parseLong(num, key)).toList());
     }
 
+    public Pattern getRequiredRegex(String key) {
+        return getRequiredProperty(key, Pattern::compile);
+    }
+
     public Optional<String> getOptionalProperty(String key) {
         return Optional.ofNullable(properties.getProperty(key));
     }
@@ -176,6 +202,10 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
 
     public Optional<List<Long>> getOptionalLongList(String key) {
         return getOptionalProperty(key, v -> Arrays.stream(v.split(",")).map(num -> parseLong(num, key)).toList());
+    }
+
+    public Optional<Pattern> getOptionalRegex(String key) {
+        return getOptionalProperty(key, Pattern::compile);
     }
 
     public String getPropertyOrDefault(String key, String defaultValue) {
@@ -282,6 +312,18 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
     }
 
     @Override
+    public Optional<Pattern> getDiscordMessageFilterPattern() { return discordMessageFilterPattern; }
+
+    @Override
+    public boolean getDiscordMessageFilterExclude() { return discordMessageFilterExclude; }
+
+    @Override
+    public Optional<List<String>> getDiscordIgnoredExternalUsers() { return discordIgnoredExternalUsers; }
+
+    @Override
+    public boolean getDiscordIgnoreBroadcast() { return discordIgnoreBroadcast; }
+
+    @Override
     public Optional<String> getDiscordLifecycleStartedFormat() { return discordLifecycleStartedFormat; }
 
     @Override
@@ -318,6 +360,15 @@ public class AMCDBPropertiesConfig implements AMCDBConfig, DiscordConfig, Minecr
     public String getMinecraftMessageFormat() {
         return minecraftMessageFormat;
     }
+
+    @Override
+    public Optional<Pattern> getMinecraftMessageFilterPattern() { return minecraftMessageFilterPattern; }
+
+    @Override
+    public boolean getMinecraftMessageFilterExclude() { return minecraftMessageFilterExclude; }
+
+    @Override
+    public Optional<List<String>> getMinecraftIgnoredExternalUsers() { return minecraftIgnoredExternalUsers; }
 
     @Override
     public String getMinecraftAvatarApiUrl() { return minecraftAvatarApiUrl; }

--- a/src/main/java/network/parthenon/amcdb/config/DiscordConfig.java
+++ b/src/main/java/network/parthenon/amcdb/config/DiscordConfig.java
@@ -3,6 +3,7 @@ package network.parthenon.amcdb.config;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.regex.Pattern;
 
 public interface DiscordConfig {
 
@@ -27,6 +28,14 @@ public interface DiscordConfig {
     String getDiscordWebhookChatMessageFormat();
 
     String getDiscordBroadcastMessageFormat();
+
+    Optional<Pattern> getDiscordMessageFilterPattern();
+
+    boolean getDiscordMessageFilterExclude();
+
+    Optional<List<String>> getDiscordIgnoredExternalUsers();
+
+    boolean getDiscordIgnoreBroadcast();
 
     Optional<String> getDiscordLifecycleStartedFormat();
 

--- a/src/main/java/network/parthenon/amcdb/config/MinecraftConfig.java
+++ b/src/main/java/network/parthenon/amcdb/config/MinecraftConfig.java
@@ -1,10 +1,20 @@
 package network.parthenon.amcdb.config;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
 public interface MinecraftConfig {
 
     boolean getMinecraftTextColorsEnabled();
 
     String getMinecraftMessageFormat();
+
+    Optional<Pattern> getMinecraftMessageFilterPattern();
+
+    boolean getMinecraftMessageFilterExclude();
+
+    Optional<List<String>> getMinecraftIgnoredExternalUsers();
 
     String getMinecraftAvatarApiUrl();
 

--- a/src/main/java/network/parthenon/amcdb/messaging/component/EntityReference.java
+++ b/src/main/java/network/parthenon/amcdb/messaging/component/EntityReference.java
@@ -21,11 +21,11 @@ public class EntityReference implements InternalMessageComponent {
     private final EnumSet<Style> appliedStyles;
 
     public EntityReference(String entityId) {
-        this(entityId, entityId, null, null, EnumSet.noneOf(Style.class), null);
+        this(entityId, entityId, entityId, null, EnumSet.noneOf(Style.class), null);
     }
 
     public EntityReference(String entityId, String displayName) {
-        this(entityId, displayName, null, null, EnumSet.noneOf(Style.class), null);
+        this(entityId, displayName, displayName, null, EnumSet.noneOf(Style.class), null);
     }
 
     public EntityReference(String entityId, String displayName, String alternateName) {
@@ -48,7 +48,7 @@ public class EntityReference implements InternalMessageComponent {
             EnumSet<Style> appliedStyles,
             String imageUrl) {
         if(entityId == null) {
-            throw new IllegalArgumentException("userId must not be null");
+            throw new IllegalArgumentException("entityId must not be null");
         }
         if(displayName == null) {
             throw new IllegalArgumentException("displayName must not be null");

--- a/src/main/java/network/parthenon/amcdb/minecraft/InGameMessageHandler.java
+++ b/src/main/java/network/parthenon/amcdb/minecraft/InGameMessageHandler.java
@@ -108,15 +108,16 @@ public class InGameMessageHandler {
      * @return
      */
     private EntityReference playerToUserReference(ServerPlayerEntity player) {
+        //#if MC>=12003
+        String playerName = player.getName().getString();
+        //#else
+        //$$ String playerName = player.getEntityName();
+        //#endif
         return new EntityReference(
                 player.getUuidAsString(),
-                //#if MC>=12003
-                player.getName().getString(),
-                //#else
-                //$$ player.getEntityName(),
-                //#endif
-                null,
-                formatter.toJavaColor(player.getTeamColorValue()),
+                playerName,
+                playerName,
+                MinecraftFormatter.toJavaColor(player.getTeamColorValue()),
                 EnumSet.noneOf(InternalMessageComponent.Style.class),
                 playerAvatarUrl(player));
     }

--- a/src/main/resources/amcdb.properties
+++ b/src/main/resources/amcdb.properties
@@ -90,6 +90,21 @@ amcdb.discord.webhookChatMessageFormat=%message%
 # If you want to display the actual % sign, use "\\%".
 amcdb.discord.broadcastMessageFormat=%message%
 
+# Regular expression to control which in-game messages are shown in Discord.
+# If this is not set, all messages are sent to Discord.
+# Note that this affects only the chat channel, not the console channel.
+#amcdb.discord.messageFilter.pattern=
+
+# If true, messages matching the filter pattern are ignored and not shown in Discord (this is the default).
+# If false, the message filter pattern has the opposite effect: only messages matching the filter are shown.
+amcdb.discord.messageFilter.exclude=true
+
+# Comma-separated list of external users (e.g. Minecraft accounts) whose messages should not appear in Discord.
+#amcdb.discord.ignoredExternalUsers=
+
+# If enabled, broadcast messages (e.g. in-game achievements) will not be shown in Discord.
+amcdb.discord.ignoreBroadcast=false
+
 # Format for server lifecycle (e.g. started/stopped) messages shown in the Discord chat channel.
 # Comment these to disable the messages from appearing in Discord.
 # You can customize the display of messages with these placeholders:
@@ -155,6 +170,21 @@ amcdb.minecraft.showTextColors=true
 #   - %username% : The name of the user who sent the message (see also amcdb.discord.useServerNicknames).
 # If you want to display the actual % sign, use "\\%".
 amcdb.minecraft.messageFormat=[AMCDB] (%origin%) %username%: %message%
+
+# Regular expression to control which external messages (e.g. from Discord) are shown in game.
+# If this is not set, all messages are sent to Minecraft.
+# Mode can be 'exclude' (all *but* the matching messages are shown) or 'include'
+# (*only* the matching messages are shown).
+#amcdb.minecraft.messageFilter.pattern=
+
+# If true, messages matching the filter pattern are ignored and not shown in game (this is the default).
+# If false, the message filter pattern has the opposite effect: only messages matching the filter are shown.
+amcdb.minecraft.messageFilter.exclude=true
+
+# Comma-separated list of external users whose messages should not appear in Minecraft.
+# This feature could be used to ignore messages from a Discord bot, for example.
+# This list should contain actual Discord account names/tags, not server nicknames or display names.
+#amcdb.minecraft.ignoredExternalUsers=
 
 # URL for Minecraft head avatars. You can use the following placeholders:
 #   - %playerUuid% : The UUID of the player, e.g. c06f8906-4c8a-4911-9c29-ea1dbd1aab82

--- a/src/main/resources/amcdb.properties
+++ b/src/main/resources/amcdb.properties
@@ -102,7 +102,7 @@ amcdb.discord.messageFilter.exclude=true
 # Comma-separated list of external users (e.g. Minecraft accounts) whose messages should not appear in Discord.
 #amcdb.discord.ignoredExternalUsers=
 
-# If enabled, broadcast messages (e.g. in-game achievements) will not be shown in Discord.
+# If enabled, broadcast messages (e.g. player join/leave messages, achievements) will not be shown in Discord.
 amcdb.discord.ignoreBroadcast=false
 
 # Format for server lifecycle (e.g. started/stopped) messages shown in the Discord chat channel.


### PR DESCRIPTION
Fixes #43 

- Messages can now be filtered by content using regular expressions
- Specific Discord and Minecraft accounts can now be ignored if desired (e.g. bots)
- Minecraft broadcast messages (e.g. player join/leave, advancements) can now be ignored