### PR TITLE
Evironment variable support in config file

### DIFF
--- a/src/main/resources/amcdb.properties
+++ b/src/main/resources/amcdb.properties
@@ -2,6 +2,10 @@
 ## AMCDB Configuration File ##
 ##############################
 
+# This file supports reading from environment variables specified as 'env:VARIABLE_NAME'
+# e.g.
+# amcdb.discord.bot.token=env:DISCORD_TOKEN
+
 # =============================
 # General Discord configuration
 # =============================


### PR DESCRIPTION
I wanted to use environment variables to store sensitive information in my config file, so I quickly implemented it. Figured I'd open this PR in case you wanted it.

Syntax is simple: just set a property value to `env:VARIABLE_NAME` to read from the variable named `VARIABLE_NAME`. There's no interpolation support or anything fancy. Should work for all existing properties and any future ones using the same reader functions.

Currently using it on a 1.20 server. All seems well.